### PR TITLE
passing db url

### DIFF
--- a/database/docker-compose.yml
+++ b/database/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - "db"
     restart: always
     environment:
+      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
       ## postgres database to store Hasura metadata
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
       ## this env var can be used to add the above postgres database to Hasura as a data source. this can be removed/updated based on your needs


### PR DESCRIPTION
this enables us to not have to type in the connection string every time we spin up a new container